### PR TITLE
Replaced Coordinator for compatibility with recent version of Android…

### DIFF
--- a/src/android/fancy-notifications/src/main/res/layout/bridge_layout_main.xml
+++ b/src/android/fancy-notifications/src/main/res/layout/bridge_layout_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"


### PR DESCRIPTION
I was getting a crash on Android 29, because the android.support.design.widget isn't available anymore.

This modification fixed that by using recent AndroidX Class instead